### PR TITLE
Fix RPC response validation and topic reallocation churn

### DIFF
--- a/cy/cy.c
+++ b/cy/cy.c
@@ -3929,7 +3929,8 @@ static cy_err_t do_respond(cy_breadcrumb_t* const breadcrumb,
 cy_err_t cy_respond(cy_breadcrumb_t* const breadcrumb, const cy_us_t deadline, const cy_bytes_t message)
 {
     cy_err_t err = CY_ERR_ARGUMENT;
-    if ((breadcrumb != NULL) && (breadcrumb->cy != NULL) && (deadline >= 0)) {
+    if ((breadcrumb != NULL) && (breadcrumb->cy != NULL) && (CY_PRIO_COUNT > (size_t)breadcrumb->priority) &&
+        (deadline >= 0) && !((message.data == NULL) && (message.size > 0))) {
         err = do_respond(breadcrumb, deadline, message, header_rsp_be, 0xFF); // arbitrary tag value
         breadcrumb->seqno++; // Increment always in case of partial send success.
     }

--- a/cy/cy.c
+++ b/cy/cy.c
@@ -995,10 +995,10 @@ struct cy_topic_t
     // The tag counter is random-initialized when topic created, then incremented with each publish.
     //
     // The subject writer is created lazily when the application attempts to publish on the topic;
-    // it is not destroyed until the topic is reallocated or destroyed to avoid losing transport-related states,
-    // whatever they may be (e.g., the transfer-ID counter etc, depending on the transport implementation).
-    // When the topic is reallocated, the old writer is destroyed unless we take over an occupied subject-ID and
-    // inherit the displaced topic's existing writer; otherwise the new writer is created on the next publication.
+    // same-subject reallocations retain it to avoid losing transport-related states, whatever they may be (e.g., the
+    // transfer-ID counter etc, depending on the transport implementation).
+    // When the topic moves to another subject, the old writer is destroyed unless we take over an occupied subject-ID
+    // and inherit the displaced topic's existing writer; otherwise the new writer is created on the next publication.
     uint64_t   pub_tag_baseline; // Randomly chosen once when topic created.
     uint64_t   pub_seqno;        // Grows from zero, added to the tag baseline to obtain the tag.
     size_t     pub_count;        // Number of active advertisements; counted for garbage collection.
@@ -1346,8 +1346,8 @@ static cy_topic_t* topic_find_by_subject_id(const cy_t* const cy, const uint32_t
     return topic;
 }
 
-// Subject writers are created lazily via the writer registry and never released until the topic is reallocated
-// or destroyed. This avoids state loss on the platform side if the application opts to publish intermittently.
+// Subject writers are created lazily via the writer registry and retained across same-subject reallocations.
+// This avoids state loss on the platform side if the application opts to publish intermittently.
 static cy_err_t topic_sync_subject_writer(cy_topic_t* const topic)
 {
     if (topic->pub_writer == NULL) {
@@ -1420,6 +1420,8 @@ static void topic_allocate(cy_topic_t* const topic, const uint32_t new_evictions
              (void*)topic->couplings);
 #endif
 
+    const uint32_t old_sid = topic_subject_id(topic);
+
     // We're not allowed to alter the eviction counter as long as the topic remains in the tree! So we remove it first.
     // We use _if() version because the topic is not in the index if it's new or if we're re-entering recursively.
     cavl2_remove_if(&cy->topics_by_subject_id, &topic->index_subject_id);
@@ -1443,13 +1445,12 @@ static void topic_allocate(cy_topic_t* const topic, const uint32_t new_evictions
     }
 
     // This mirrors the formal specification of AllocateTopic(t, topics) given in Core.tla.
-    // Note that it is possible that subject_id(hash,old_evictions) == subject_id(hash,new_evictions),
-    // meaning that we stay with the same subject-ID. No special case is required to handle this.
     const uint32_t    new_sid = topic_subject_id_impl(topic->hash, new_evictions, cy->platform->subject_id_modulus);
     cy_topic_t* const that    = CAVL2_TO_OWNER(
       cavl2_find(cy->topics_by_subject_id, &new_sid, &cavl_comp_topic_subject_id), cy_topic_t, index_subject_id);
     assert((that == NULL) || (topic->hash != that->hash)); // This would mean that we inserted the same topic twice
-    const bool victory = (that == NULL) || left_wins(topic, now, topic_lage(that, now), that->hash);
+    const bool same_subject = new_sid == old_sid;
+    const bool victory      = (that == NULL) || left_wins(topic, now, topic_lage(that, now), that->hash);
 
 #if CY_CONFIG_TRACE
     if (that != NULL) {
@@ -1464,13 +1465,15 @@ static void topic_allocate(cy_topic_t* const topic, const uint32_t new_evictions
 #endif
 
     if (victory) { // Allocation done. Every affected topic will end up here eventually.
-        // Release old handles for the subject we're leaving.
-        if (topic->sub_reader != NULL) {
+        // Release old handles only for the subject we're leaving.
+        assert((topic->sub_reader == NULL) || (topic->sub_reader->handle->subject_id == old_sid));
+        assert((topic->pub_writer == NULL) || (topic->pub_writer->handle->subject_id == old_sid));
+        if (!same_subject && (topic->sub_reader != NULL)) {
             assert(topic->couplings != NULL);
             reader_release(cy, topic->sub_reader);
             topic->sub_reader = NULL;
         }
-        if (topic->pub_writer != NULL) {
+        if (!same_subject && (topic->pub_writer != NULL)) {
             writer_release(cy, topic->pub_writer);
             topic->pub_writer = NULL;
         }
@@ -2142,8 +2145,8 @@ static cy_err_t do_publish_impl(cy_publisher_t* const  pub,
         return vt->unicast(cy->platform, lane, deadline, headed_message);
     }
 
-    // Lazy creation is the simplest option because we have to drop the subject writer on topic reallocation,
-    // and it may fail to be created at the time of reallocation, so we'd have to retry anyway.
+    // Lazy creation is the simplest option because a subject move may drop the writer, and reacquisition may fail,
+    // so we'd have to retry anyway.
     // The subject writer is a very lightweight entity that is super cheap to construct (constant complexity expected)
     // so this is not expected to be a problem.
     const cy_err_t err = topic_sync_subject_writer(topic);

--- a/tests/src/test_intrusive_rpc.c
+++ b/tests/src/test_intrusive_rpc.c
@@ -339,6 +339,46 @@ static void request_callback(cy_future_t* const fut)
     cap->last_error = cy_future_error(fut);
 }
 
+static void test_respond_argument_validation(void)
+{
+    fixture_t fixture;
+    fixture_init(&fixture);
+
+    const cy_bytes_t ok  = { .size = 0U, .data = NULL, .next = NULL };
+    const cy_bytes_t bad = { .size = 4U, .data = NULL, .next = NULL };
+    cy_breadcrumb_t  breadcrumb =
+      make_test_breadcrumb(&fixture, UINT64_C(0xAA00), cy_prio_nominal, UINT64_C(0x1234), UINT64_C(0x5678), 11U);
+
+    TEST_ASSERT_EQUAL_INT(CY_ERR_ARGUMENT, cy_respond(NULL, fixture.now + 1, ok));
+    TEST_ASSERT_EQUAL_INT(CY_ERR_ARGUMENT, cy_respond(&breadcrumb, -1, ok));
+
+    cy_breadcrumb_t invalid = breadcrumb;
+    invalid.cy              = NULL;
+    TEST_ASSERT_EQUAL_INT(CY_ERR_ARGUMENT, cy_respond(&invalid, fixture.now + 1, ok));
+
+    invalid = breadcrumb;
+    {
+        const uint8_t bad_priority = UINT8_MAX;
+        memset(&invalid.priority, 0, sizeof(invalid.priority));
+        memcpy(&invalid.priority, &bad_priority, sizeof(bad_priority));
+    }
+    TEST_ASSERT_EQUAL_INT(CY_ERR_ARGUMENT, cy_respond(&invalid, fixture.now + 1, ok));
+    TEST_ASSERT_EQUAL_size_t(0U, fixture.unicast_send_count);
+    TEST_ASSERT_EQUAL_UINT64(11U, invalid.seqno);
+
+    TEST_ASSERT_EQUAL_INT(CY_ERR_ARGUMENT, cy_respond(&breadcrumb, fixture.now + 1, bad));
+    TEST_ASSERT_EQUAL_size_t(0U, fixture.unicast_send_count);
+    TEST_ASSERT_EQUAL_UINT64(11U, breadcrumb.seqno);
+
+    TEST_ASSERT_EQUAL_INT(CY_OK, cy_respond(&breadcrumb, fixture.now + 2, ok));
+    TEST_ASSERT_EQUAL_size_t(1U, fixture.unicast_send_count);
+    TEST_ASSERT_EQUAL_UINT64(12U, breadcrumb.seqno);
+    TEST_ASSERT_EQUAL_UINT8(header_rsp_be, fixture.last_unicast[0]);
+    TEST_ASSERT_EQUAL_UINT64(11U, deserialize_u48(&fixture.last_unicast[2]));
+
+    fixture_assert_clean(&fixture);
+}
+
 static void test_respond_reliable_argument_validation(void)
 {
     fixture_t fixture;
@@ -1120,6 +1160,7 @@ void tearDown(void) { TEST_ASSERT_EQUAL_size_t(0U, cy_test_message_live_count())
 int main(void)
 {
     UNITY_BEGIN();
+    RUN_TEST(test_respond_argument_validation);
     RUN_TEST(test_respond_reliable_argument_validation);
     RUN_TEST(test_respond_reliable_initial_send_failure_returns_null);
     RUN_TEST(test_respond_reliable_ack_success);

--- a/tests/src/test_intrusive_topic_allocation.c
+++ b/tests/src/test_intrusive_topic_allocation.c
@@ -1206,6 +1206,121 @@ static void test_topic_allocate_destroys_existing_pub_writer_without_displacemen
     fixture_deinit(&fix);
 }
 
+static void test_topic_allocate_same_subject_reallocation_keeps_handles(void)
+{
+    fixture_t fix;
+    fixture_init(&fix);
+
+    static const char* const topic_name = "alloc/same-subject/handles";
+    cy_future_t* const       sub        = cy_subscribe(fix.cy, cy_str(topic_name), 64U);
+    TEST_ASSERT_NOT_NULL(sub);
+    cy_topic_t* const topic = cy_topic_find_by_name(fix.cy, cy_str(topic_name));
+    TEST_ASSERT_NOT_NULL(topic);
+    TEST_ASSERT_NOT_NULL(topic->sub_reader);
+
+    topic_allocate(topic, 1U, 240 * MEGA);
+    TEST_ASSERT_EQUAL_UINT32(1U, topic->evictions);
+    TEST_ASSERT_NOT_NULL(topic->sub_reader);
+    const uint32_t sid = topic_subject_id(topic);
+
+    TEST_ASSERT_EQUAL_INT(CY_OK, topic_sync_subject_writer(topic));
+    TEST_ASSERT_NOT_NULL(topic->pub_writer);
+    reader_t* const reader                 = topic->sub_reader;
+    writer_t* const writer                 = topic->pub_writer;
+    const size_t    reader_refcount        = reader->refcount;
+    const size_t    writer_refcount        = writer->refcount;
+    const size_t    reader_destroy_count   = fix.subject_reader_destroy_count;
+    const size_t    writer_destroy_count   = fix.subject_writer_destroy_count;
+    const uint32_t  same_subject_evictions = fix.platform.subject_id_modulus - 1U;
+    TEST_ASSERT_EQUAL_UINT32(
+      sid, topic_subject_id_impl(topic->hash, same_subject_evictions, fix.platform.subject_id_modulus));
+
+    topic_allocate(topic, same_subject_evictions, 250 * MEGA);
+
+    TEST_ASSERT_EQUAL_UINT32(same_subject_evictions, topic->evictions);
+    TEST_ASSERT_EQUAL_UINT32(sid, topic_subject_id(topic));
+    TEST_ASSERT_EQUAL_PTR(reader, topic->sub_reader);
+    TEST_ASSERT_EQUAL_PTR(writer, topic->pub_writer);
+    TEST_ASSERT_EQUAL_size_t(reader_destroy_count, fix.subject_reader_destroy_count);
+    TEST_ASSERT_EQUAL_size_t(writer_destroy_count, fix.subject_writer_destroy_count);
+    TEST_ASSERT_EQUAL_size_t(reader_refcount, topic->sub_reader->refcount);
+    TEST_ASSERT_EQUAL_size_t(writer_refcount, topic->pub_writer->refcount);
+    TEST_ASSERT_EQUAL_UINT32(sid, topic->sub_reader->handle->subject_id);
+    TEST_ASSERT_EQUAL_UINT32(sid, topic->pub_writer->handle->subject_id);
+    TEST_ASSERT_TRUE(topic_find_by_subject_id(fix.cy, sid) == topic);
+    subject_tracker_assert_contains(&fix.active_readers, sid);
+    subject_tracker_assert_contains(&fix.active_writers, sid);
+    assert_subject_index_unique(fix.cy);
+
+    cy_future_destroy(sub);
+    TEST_ASSERT_EQUAL_INT(CY_OK, cy_spin_once(fix.cy));
+    fixture_deinit(&fix);
+}
+
+static void test_topic_allocate_recursive_same_subject_reallocation_keeps_handles(void)
+{
+    fixture_t fix;
+    fixture_init(&fix);
+
+    static const char* const topic_name = "alloc/same-subject/recursive/handles";
+    cy_future_t* const       sub        = cy_subscribe(fix.cy, cy_str(topic_name), 64U);
+    TEST_ASSERT_NOT_NULL(sub);
+    cy_topic_t* const topic = cy_topic_find_by_name(fix.cy, cy_str(topic_name));
+    TEST_ASSERT_NOT_NULL(topic);
+    TEST_ASSERT_NOT_NULL(topic->sub_reader);
+
+    topic_allocate(topic, 1U, 260 * MEGA);
+    TEST_ASSERT_EQUAL_UINT32(1U, topic->evictions);
+    const uint32_t sid = topic_subject_id(topic);
+
+    const uint64_t p                   = fix.platform.subject_id_modulus;
+    const uint32_t losing_evictions    = fix.platform.subject_id_modulus - 2U;
+    const uint32_t same_subject_evicts = fix.platform.subject_id_modulus - 1U;
+    const uint32_t blocked_sid = topic_subject_id_impl(topic->hash, losing_evictions, fix.platform.subject_id_modulus);
+    const uint64_t blocked_residue = (uint64_t)(blocked_sid - (CY_SUBJECT_ID_PINNED_MAX + 1U));
+    uint64_t       blocker_hash    = (topic->hash - (topic->hash % p)) + blocked_residue;
+    if (blocker_hash == topic->hash) {
+        blocker_hash += p;
+    }
+    cy_topic_t* const blocker =
+      fixture_make_topic(&fix, "alloc/same-subject/recursive/blocker", blocker_hash, 0U, LAGE_MIN);
+    topic_merge_lage(blocker, 270 * MEGA, 10);
+    TEST_ASSERT_EQUAL_UINT32(blocked_sid, topic_subject_id(blocker));
+    TEST_ASSERT_TRUE(topic_subject_id(blocker) != sid);
+    TEST_ASSERT_FALSE(left_wins(topic, 270 * MEGA, topic_lage(blocker, 270 * MEGA), blocker->hash));
+
+    TEST_ASSERT_EQUAL_INT(CY_OK, topic_sync_subject_writer(topic));
+    TEST_ASSERT_NOT_NULL(topic->pub_writer);
+    reader_t* const reader               = topic->sub_reader;
+    writer_t* const writer               = topic->pub_writer;
+    const size_t    reader_refcount      = reader->refcount;
+    const size_t    writer_refcount      = writer->refcount;
+    const size_t    reader_destroy_count = fix.subject_reader_destroy_count;
+    const size_t    writer_destroy_count = fix.subject_writer_destroy_count;
+    TEST_ASSERT_EQUAL_UINT32(sid,
+                             topic_subject_id_impl(topic->hash, same_subject_evicts, fix.platform.subject_id_modulus));
+
+    topic_allocate(topic, losing_evictions, 270 * MEGA);
+
+    TEST_ASSERT_EQUAL_UINT32(same_subject_evicts, topic->evictions);
+    TEST_ASSERT_EQUAL_UINT32(sid, topic_subject_id(topic));
+    TEST_ASSERT_EQUAL_PTR(reader, topic->sub_reader);
+    TEST_ASSERT_EQUAL_PTR(writer, topic->pub_writer);
+    TEST_ASSERT_EQUAL_size_t(reader_destroy_count, fix.subject_reader_destroy_count);
+    TEST_ASSERT_EQUAL_size_t(writer_destroy_count, fix.subject_writer_destroy_count);
+    TEST_ASSERT_EQUAL_size_t(reader_refcount, topic->sub_reader->refcount);
+    TEST_ASSERT_EQUAL_size_t(writer_refcount, topic->pub_writer->refcount);
+    TEST_ASSERT_TRUE(topic_find_by_subject_id(fix.cy, sid) == topic);
+    TEST_ASSERT_TRUE(topic_find_by_subject_id(fix.cy, blocked_sid) == blocker);
+    subject_tracker_assert_contains(&fix.active_readers, sid);
+    subject_tracker_assert_contains(&fix.active_writers, sid);
+    assert_subject_index_unique(fix.cy);
+
+    cy_future_destroy(sub);
+    TEST_ASSERT_EQUAL_INT(CY_OK, cy_spin_once(fix.cy));
+    fixture_deinit(&fix);
+}
+
 static void test_on_gossip_known_topic_divergence_paths(void)
 {
     fixture_t fix;
@@ -2004,6 +2119,8 @@ int main(void)
     RUN_TEST(test_topic_allocate_reader_recovery_after_subject_reader_oom);
     RUN_TEST(test_topic_sync_subject_writer_reports_oom);
     RUN_TEST(test_topic_allocate_destroys_existing_pub_writer_without_displacement);
+    RUN_TEST(test_topic_allocate_same_subject_reallocation_keeps_handles);
+    RUN_TEST(test_topic_allocate_recursive_same_subject_reallocation_keeps_handles);
     RUN_TEST(test_on_gossip_known_topic_divergence_paths);
     RUN_TEST(test_on_gossip_unknown_topic_collision_paths);
     RUN_TEST(test_topic_allocate_recursive_chain_converges_and_writer_transfers);

--- a/todo/resolved/L12-cy-respond-message-validation.md
+++ b/todo/resolved/L12-cy-respond-message-validation.md
@@ -3,7 +3,7 @@
 - **Severity:** 🟡 LOW (report L-12 / L-F5)
 - **Confidence:** verified (code trace)
 - **Subsystem:** core (`cy/cy.c`, RPC response)
-- **Status:** OPEN
+- **Status:** RESOLVED
 
 ## Summary
 `cy_publish`, `cy_publish_reliable`, `cy_request`, and `cy_respond_reliable` all reject a message with

--- a/todo/resolved/L17-same-subject-realloc-churn.md
+++ b/todo/resolved/L17-same-subject-realloc-churn.md
@@ -3,7 +3,7 @@
 - **Severity:** 🟡 LOW (report L-17 / CRDT-F14, L-F weaker)
 - **Confidence:** verified (code trace)
 - **Subsystem:** core (`cy/cy.c`, `topic_allocate` victory branch)
-- **Status:** OPEN
+- **Status:** RESOLVED
 
 ## Summary
 When a topic's probe sequence cycles back to its *current* subject-ID (possible because `subject_id(hash, e)` is
@@ -30,10 +30,10 @@ subject-ID should not tear down transport state.
 - Wire into `ctest` (extend `test_intrusive_topic_allocation`).
 
 ## Acceptance criteria
-- [ ] A reallocation that keeps the same subject-ID does not destroy/recreate the platform reader/writer.
-- [ ] Allocation results and diagnostics are otherwise unchanged (CRDT equivalence preserved).
-- [ ] No refcount imbalance or OOM window introduced.
-- [ ] Full suite, incl. `test_intrusive_topic_allocation` / `_exhaustive`, green.
+- [x] A reallocation that keeps the same subject-ID does not destroy/recreate the platform reader/writer.
+- [x] Allocation results and diagnostics are otherwise unchanged (CRDT equivalence preserved).
+- [x] No refcount imbalance or OOM window introduced.
+- [x] Full suite, incl. `test_intrusive_topic_allocation` / `_exhaustive`, green.
 
 ## Verification notes (adversarial cross-check)
 - I will confirm the handle survives via the subject-tracker (no destroy event) for a same-subject reallocation, and


### PR DESCRIPTION
## Summary
- Harden `cy_respond()` argument validation so malformed NULL-data/nonzero-size payloads and invalid breadcrumb priorities are rejected before platform unicast, without advancing the response sequence number.
- Preserve topic reader/writer handles when `topic_allocate()` changes eviction count but maps back to the same subject-ID, while leaving subject moves, displacement handling, gossip scheduling, and diagnostics semantics intact.
- Add intrusive regressions for both changes and move the L12/L17 TODO records into `todo/resolved/`.

## Branch commits
- `62eea1d` `Fix cy_respond argument validation`
- `0d29e96` `Fix same-subject topic reallocation churn`

## Verification
- `cmake --build build-l17 --parallel --target test_intrusive_topic_allocation_x64_c11 test_intrusive_topic_allocate_exhaustive_x64_c11`
- `ctest --test-dir build-l17 -R 'run_test_intrusive_topic_(allocation|allocate_exhaustive)_x64_c11' --output-on-failure`
- `cmake --build build-l17 --parallel`
- `ctest --test-dir build-l17 --output-on-failure` (105/105 passed)
- `git diff --check origin/main..dev`
- C comment-line delta check: `added_comment_lines=9 removed_comment_lines=11`
- Review loop: 3 consecutive clean rounds, including Claude Fable 5/xhigh correctness review, no major/significant findings.
