### PR TITLE
Enable CI for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
   push:
-    paths-ignore:
+    branches:
+      - main
+    paths-ignore: &paths-ignore
       - "papers/**"
       - "model/tlaplus/**"
       - "**/*.md"
@@ -13,6 +15,10 @@ on:
       - ".idea/**"
       - ".zed/**"
       - ".vscode/**"
+  pull_request:
+    branches:
+      - main
+    paths-ignore: *paths-ignore
 
 jobs:
   test_debug_with_static_analysis:


### PR DESCRIPTION
Run CI for pull requests targeting main while limiting push-triggered CI to main, avoiding duplicate runs for internal feature branches.